### PR TITLE
Refactor UI to flat, app-like layout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import SearchResults from "./pages/SearchResults";
 function App() {
   const [email, setEmail] = useState<string | undefined>();
   const [checked, setChecked] = useState(false);
+  const [currentUrl, setCurrentUrl] = useState(window.location.pathname);
 
   useEffect(() => {
     getAuthStatus()
@@ -40,8 +41,10 @@ function App() {
   }
 
   return (
-    <Layout email={email}>
-      <Router>
+    <Layout email={email} currentUrl={currentUrl}>
+      <Router
+        onChange={(e: { url: string }) => setCurrentUrl(e.url)}
+      >
         <Home path="/" />
         <SearchResults path="/search" />
         <PhraseDetail path="/phrases/:id" />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -3,14 +3,21 @@ import { useState } from "preact/hooks";
 import { route } from "preact-router";
 import { logout } from "../api";
 import PhraseFormModal from "./PhraseFormModal";
+import Sidebar from "./Sidebar";
 
 interface Props {
   children: ComponentChildren;
   email?: string;
+  currentUrl?: string;
 }
 
-export default function Layout({ children, email }: Props) {
+export default function Layout({
+  children,
+  email,
+  currentUrl = "/",
+}: Props) {
   const [showModal, setShowModal] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const handleLogout = async () => {
     await logout();
@@ -18,32 +25,86 @@ export default function Layout({ children, email }: Props) {
   };
 
   return (
-    <div class="min-h-screen bg-gray-50">
-      <header class="bg-white border-b border-gray-200">
-        <div class="max-w-4xl mx-auto px-4 h-14 flex items-center justify-between">
-          <a href="/" class="text-lg font-bold text-gray-900 no-underline">
+    <div class="h-screen flex flex-col bg-white">
+      {/* Top header — 56px, full width, white with bottom border */}
+      <header class="h-14 flex-shrink-0 flex items-center border-b border-gray-200 px-4 bg-white z-10">
+        <div class="flex items-center gap-3">
+          {email && (
+            <button
+              onClick={() => setSidebarOpen(!sidebarOpen)}
+              class="md:hidden p-1 -ml-1 text-gray-500 hover:text-gray-700 rounded"
+              aria-label="Toggle sidebar"
+            >
+              <svg
+                class="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                stroke-width="2"
+              >
+                <path
+                  d="M4 6h16M4 12h16M4 18h16"
+                  stroke-linecap="round"
+                />
+              </svg>
+            </button>
+          )}
+          <a
+            href="/"
+            class="text-base font-semibold text-gray-900 no-underline"
+          >
             Semleaf
           </a>
-          {email && (
-            <div class="flex items-center gap-4">
-              <button
-                onClick={() => setShowModal(true)}
-                class="text-sm text-blue-600 hover:text-blue-800"
-              >
-                + New
-              </button>
-              <span class="text-sm text-gray-500">{email}</span>
-              <button
-                onClick={handleLogout}
-                class="text-sm text-gray-500 hover:text-gray-700"
-              >
-                Logout
-              </button>
-            </div>
-          )}
         </div>
+
+        {email && (
+          <div class="ml-auto flex items-center gap-3">
+            <button
+              onClick={() => setShowModal(true)}
+              class="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+            >
+              + New
+            </button>
+            <span class="text-sm text-gray-500">{email}</span>
+            <button
+              onClick={handleLogout}
+              class="text-sm text-gray-500 hover:text-gray-700"
+            >
+              Logout
+            </button>
+          </div>
+        )}
       </header>
-      <main class="max-w-4xl mx-auto px-4 py-6">{children}</main>
+
+      <div class="flex flex-1 overflow-hidden">
+        {/* Sidebar — only shown when authenticated */}
+        {email && (
+          <>
+            {/* Mobile backdrop overlay */}
+            {sidebarOpen && (
+              <div
+                class="fixed inset-0 bg-black/30 z-20 md:hidden"
+                onClick={() => setSidebarOpen(false)}
+              />
+            )}
+
+            <aside
+              class={`w-60 bg-gray-50 border-r border-gray-200 flex-shrink-0 overflow-y-auto
+                fixed top-14 bottom-0 left-0 z-30 transition-transform duration-150 ease-in-out
+                md:static md:z-auto md:transition-none md:translate-x-0
+                ${sidebarOpen ? "translate-x-0" : "-translate-x-full"}`}
+            >
+              <Sidebar currentUrl={currentUrl} />
+            </aside>
+          </>
+        )}
+
+        {/* Main content area */}
+        <main class="flex-1 overflow-y-auto">
+          <div class="p-6 max-w-4xl">{children}</div>
+        </main>
+      </div>
+
       <PhraseFormModal
         open={showModal}
         onClose={() => setShowModal(false)}

--- a/frontend/src/components/PhraseCard.tsx
+++ b/frontend/src/components/PhraseCard.tsx
@@ -8,25 +8,33 @@ export default function PhraseCard({ phrase }: Props) {
   return (
     <a
       href={`/phrases/${phrase.id}`}
-      class="block p-4 bg-white rounded-lg border border-gray-200 hover:border-blue-300 hover:shadow-sm transition-all no-underline"
+      class="block px-4 py-3 hover:bg-gray-50 transition-colors no-underline"
     >
-      <p class="text-gray-900 font-medium">{phrase.phrase}</p>
-      <p class="text-sm text-gray-600 mt-1 line-clamp-2">
-        {phrase.meanings.join(" / ")}
-      </p>
-      {phrase.source && (
-        <p class="text-xs text-gray-400 mt-2">{phrase.source}</p>
-      )}
-      {phrase.tags.length > 0 && (
-        <div class="flex gap-1 mt-2 flex-wrap">
-          {phrase.tags.map((tag) => (
-            <span
-              key={tag}
-              class="px-2 py-0.5 bg-gray-100 text-gray-600 text-xs rounded-full"
-            >
-              {tag}
-            </span>
-          ))}
+      <div class="flex items-baseline gap-3">
+        <span class="text-sm font-medium text-gray-900">
+          {phrase.phrase}
+        </span>
+        <span class="text-sm text-gray-500 truncate">
+          {phrase.meanings.join(" / ")}
+        </span>
+      </div>
+      {(phrase.source || phrase.tags.length > 0) && (
+        <div class="flex items-center gap-2 mt-1">
+          {phrase.source && (
+            <span class="text-xs text-gray-400">{phrase.source}</span>
+          )}
+          {phrase.tags.length > 0 && (
+            <div class="flex gap-1 flex-wrap">
+              {phrase.tags.map((tag) => (
+                <span
+                  key={tag}
+                  class="px-1.5 py-0 bg-gray-100 text-gray-600 text-xs rounded"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
       )}
     </a>

--- a/frontend/src/components/PhraseFormModal.tsx
+++ b/frontend/src/components/PhraseFormModal.tsx
@@ -101,11 +101,11 @@ export default function PhraseFormModal({ open, onClose, onCreated }: Props) {
     <dialog
       ref={dialogRef}
       onClick={handleBackdropClick}
-      class="p-0 rounded-xl shadow-2xl backdrop:bg-black/50 max-w-2xl w-full"
+      class="p-0 rounded shadow-lg backdrop:bg-black/50 max-w-2xl w-full"
     >
       <div class="p-6">
         <div class="flex items-center justify-between mb-4">
-          <h2 class="text-xl font-bold text-gray-900">New Phrase</h2>
+          <h2 class="text-lg font-semibold text-gray-900">New Phrase</h2>
           <button
             type="button"
             onClick={handleClose}
@@ -115,7 +115,7 @@ export default function PhraseFormModal({ open, onClose, onCreated }: Props) {
           </button>
         </div>
 
-        {error && <p class="text-red-500 mb-4">{error}</p>}
+        {error && <p class="text-sm text-red-600 mb-4">{error}</p>}
 
         <form onSubmit={handleSubmit} class="space-y-4">
           <div>
@@ -125,8 +125,10 @@ export default function PhraseFormModal({ open, onClose, onCreated }: Props) {
             <input
               type="text"
               value={phrase}
-              onInput={(e) => setPhrase((e.target as HTMLInputElement).value)}
-              class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+              onInput={(e) =>
+                setPhrase((e.target as HTMLInputElement).value)
+              }
+              class="w-full px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
               required
             />
           </div>
@@ -142,17 +144,20 @@ export default function PhraseFormModal({ open, onClose, onCreated }: Props) {
                     type="text"
                     value={meaning}
                     onInput={(e) =>
-                      updateMeaning(index, (e.target as HTMLInputElement).value)
+                      updateMeaning(
+                        index,
+                        (e.target as HTMLInputElement).value,
+                      )
                     }
                     placeholder={`Meaning ${index + 1}`}
-                    class="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    class="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
                     required
                   />
                   {meanings.length > 1 && (
                     <button
                       type="button"
                       onClick={() => removeMeaning(index)}
-                      class="px-3 py-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors text-sm"
+                      class="px-3 py-1.5 text-red-600 hover:bg-red-50 rounded transition-colors text-sm"
                     >
                       Remove
                     </button>
@@ -163,7 +168,7 @@ export default function PhraseFormModal({ open, onClose, onCreated }: Props) {
             <button
               type="button"
               onClick={addMeaning}
-              class="mt-2 px-3 py-1 text-blue-600 hover:bg-blue-50 rounded-lg transition-colors text-sm"
+              class="mt-2 px-3 py-1 text-blue-600 hover:bg-blue-50 rounded transition-colors text-sm"
             >
               + Add meaning
             </button>
@@ -176,8 +181,10 @@ export default function PhraseFormModal({ open, onClose, onCreated }: Props) {
             <input
               type="text"
               value={source}
-              onInput={(e) => setSource((e.target as HTMLInputElement).value)}
-              class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+              onInput={(e) =>
+                setSource((e.target as HTMLInputElement).value)
+              }
+              class="w-full px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
             />
           </div>
 
@@ -194,24 +201,26 @@ export default function PhraseFormModal({ open, onClose, onCreated }: Props) {
             </label>
             <textarea
               value={memo}
-              onInput={(e) => setMemo((e.target as HTMLTextAreaElement).value)}
+              onInput={(e) =>
+                setMemo((e.target as HTMLTextAreaElement).value)
+              }
               rows={2}
-              class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+              class="w-full px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
             />
           </div>
 
-          <div class="flex gap-3 pt-2">
+          <div class="flex gap-2 pt-2">
             <button
               type="submit"
               disabled={loading}
-              class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 text-sm"
+              class="px-4 py-1.5 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 transition-colors disabled:opacity-50"
             >
               {loading ? "Saving..." : "Create"}
             </button>
             <button
               type="button"
               onClick={handleClose}
-              class="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors text-sm"
+              class="px-4 py-1.5 text-sm border border-gray-300 text-gray-700 rounded hover:bg-gray-50 transition-colors"
             >
               Cancel
             </button>

--- a/frontend/src/components/SearchBox.tsx
+++ b/frontend/src/components/SearchBox.tsx
@@ -6,7 +6,10 @@ interface Props {
   initialMode?: SearchMode;
 }
 
-export default function SearchBox({ onSearch, initialMode = "semantic" }: Props) {
+export default function SearchBox({
+  onSearch,
+  initialMode = "semantic",
+}: Props) {
   const [query, setQuery] = useState("");
   const [mode, setMode] = useState<SearchMode>(initialMode);
 
@@ -18,48 +21,46 @@ export default function SearchBox({ onSearch, initialMode = "semantic" }: Props)
   };
 
   return (
-    <form onSubmit={handleSubmit} class="w-full">
-      <div class="flex gap-2">
-        <input
-          type="text"
-          value={query}
-          onInput={(e) => setQuery((e.target as HTMLInputElement).value)}
-          placeholder={
-            mode === "semantic"
-              ? "Search by meaning..."
-              : "Search by text..."
-          }
-          class="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-        />
+    <form onSubmit={handleSubmit} class="flex items-center gap-2">
+      <input
+        type="text"
+        value={query}
+        onInput={(e) => setQuery((e.target as HTMLInputElement).value)}
+        placeholder={
+          mode === "semantic" ? "Search by meaning..." : "Search by text..."
+        }
+        class="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+      />
+      <div class="flex border border-gray-300 rounded overflow-hidden text-sm flex-shrink-0">
         <button
-          type="submit"
-          class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+          type="button"
+          onClick={() => setMode("semantic")}
+          class={`px-3 py-1.5 transition-colors ${
+            mode === "semantic"
+              ? "bg-blue-600 text-white"
+              : "bg-white text-gray-600 hover:bg-gray-50"
+          }`}
         >
-          Search
+          Semantic
+        </button>
+        <button
+          type="button"
+          onClick={() => setMode("text")}
+          class={`px-3 py-1.5 border-l border-gray-300 transition-colors ${
+            mode === "text"
+              ? "bg-blue-600 text-white"
+              : "bg-white text-gray-600 hover:bg-gray-50"
+          }`}
+        >
+          Text
         </button>
       </div>
-      <div class="flex gap-4 mt-2">
-        <label class="flex items-center gap-1 text-sm text-gray-600 cursor-pointer">
-          <input
-            type="radio"
-            name="mode"
-            checked={mode === "semantic"}
-            onChange={() => setMode("semantic")}
-            class="accent-blue-600"
-          />
-          Semantic
-        </label>
-        <label class="flex items-center gap-1 text-sm text-gray-600 cursor-pointer">
-          <input
-            type="radio"
-            name="mode"
-            checked={mode === "text"}
-            onChange={() => setMode("text")}
-            class="accent-blue-600"
-          />
-          Text
-        </label>
-      </div>
+      <button
+        type="submit"
+        class="px-4 py-1.5 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 transition-colors flex-shrink-0"
+      >
+        Search
+      </button>
     </form>
   );
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,85 @@
+interface Props {
+  currentUrl: string;
+}
+
+interface NavItem {
+  label: string;
+  href: string;
+  matchPaths: string[];
+  icon: "search" | "list";
+}
+
+const viewItems: NavItem[] = [
+  { label: "Search", href: "/", matchPaths: ["/", "/search"], icon: "search" },
+  {
+    label: "Phrases",
+    href: "/",
+    matchPaths: ["/phrases"],
+    icon: "list",
+  },
+];
+
+function NavIcon({ type }: { type: NavItem["icon"] }) {
+  const cls = "w-4 h-4 flex-shrink-0";
+  switch (type) {
+    case "search":
+      return (
+        <svg
+          class={cls}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          stroke-width="2"
+        >
+          <circle cx="11" cy="11" r="8" />
+          <path d="m21 21-4.35-4.35" stroke-linecap="round" />
+        </svg>
+      );
+    case "list":
+      return (
+        <svg
+          class={cls}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          stroke-width="2"
+        >
+          <path d="M4 6h16M4 12h16M4 18h12" stroke-linecap="round" />
+        </svg>
+      );
+  }
+}
+
+export default function Sidebar({ currentUrl }: Props) {
+  const isActive = (item: NavItem) =>
+    item.matchPaths.some(
+      (p) =>
+        currentUrl === p ||
+        currentUrl.startsWith(p + "?") ||
+        (p !== "/" && currentUrl.startsWith(p + "/")),
+    );
+
+  return (
+    <nav class="h-full overflow-y-auto py-3">
+      <div class="px-4 mb-1">
+        <span class="text-[11px] font-semibold text-gray-400 uppercase tracking-wider">
+          Views
+        </span>
+      </div>
+      {viewItems.map((item) => (
+        <a
+          key={item.label}
+          href={item.href}
+          class={`flex items-center gap-2.5 mx-2 px-2 h-8 text-sm rounded no-underline transition-colors ${
+            isActive(item)
+              ? "bg-gray-200 text-gray-900 font-medium"
+              : "text-gray-600 hover:bg-gray-100"
+          }`}
+        >
+          <NavIcon type={item.icon} />
+          {item.label}
+        </a>
+      ))}
+    </nav>
+  );
+}

--- a/frontend/src/components/TagInput.tsx
+++ b/frontend/src/components/TagInput.tsx
@@ -33,13 +33,13 @@ export default function TagInput({ tags, onChange }: Props) {
         {tags.map((tag) => (
           <span
             key={tag}
-            class="inline-flex items-center gap-1 px-2 py-1 bg-blue-100 text-blue-800 text-sm rounded-full"
+            class="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-100 text-gray-700 text-sm rounded"
           >
             {tag}
             <button
               type="button"
               onClick={() => removeTag(tag)}
-              class="text-blue-600 hover:text-blue-900"
+              class="text-gray-500 hover:text-gray-700"
             >
               &times;
             </button>
@@ -53,12 +53,12 @@ export default function TagInput({ tags, onChange }: Props) {
           onInput={(e) => setInput((e.target as HTMLInputElement).value)}
           onKeyDown={handleKeyDown}
           placeholder="Add tag..."
-          class="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+          class="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
         />
         <button
           type="button"
           onClick={addTag}
-          class="px-3 py-1.5 text-sm bg-gray-200 rounded-lg hover:bg-gray-300"
+          class="px-3 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 transition-colors"
         >
           Add
         </button>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -27,17 +27,20 @@ export default function Home(_props: Props) {
   };
 
   return (
-    <div class="flex flex-col items-center justify-center min-h-[60vh] gap-8">
-      <h1 class="text-4xl font-bold text-gray-900">Semleaf</h1>
-      <div class="w-full max-w-lg">
+    <div>
+      <div class="flex items-center justify-end mb-4">
+        <button
+          onClick={() => setShowModal(true)}
+          class="px-3 py-1.5 text-sm border border-gray-300 rounded text-gray-700 hover:bg-gray-50 transition-colors"
+        >
+          + New Phrase
+        </button>
+      </div>
+
+      <div class="mb-6">
         <SearchBox onSearch={handleSearch} />
       </div>
-      <button
-        onClick={() => setShowModal(true)}
-        class="px-6 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors"
-      >
-        + New Phrase
-      </button>
+
       <PhraseFormModal
         open={showModal}
         onClose={() => setShowModal(false)}
@@ -46,15 +49,23 @@ export default function Home(_props: Props) {
           setShowModal(false);
         }}
       />
-      {loading ? (
-        <p class="text-gray-400 text-sm">Loading...</p>
-      ) : phrases.length > 0 ? (
-        <div class="w-full max-w-2xl flex flex-col gap-3">
-          {phrases.map((p) => (
-            <PhraseCard key={p.id} phrase={p} />
-          ))}
-        </div>
-      ) : null}
+
+      <div class="mt-6">
+        <h2 class="text-xs font-medium text-gray-400 uppercase tracking-wider mb-3">
+          Recent Phrases
+        </h2>
+        {loading ? (
+          <p class="text-sm text-gray-400">Loading...</p>
+        ) : phrases.length > 0 ? (
+          <div class="border border-gray-200 rounded divide-y divide-gray-200">
+            {phrases.map((p) => (
+              <PhraseCard key={p.id} phrase={p} />
+            ))}
+          </div>
+        ) : (
+          <p class="text-sm text-gray-400">No phrases yet.</p>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,11 +1,11 @@
 export default function Login() {
   return (
-    <div class="flex flex-col items-center justify-center min-h-[80vh] gap-6">
-      <h1 class="text-3xl font-bold text-gray-900">Semleaf</h1>
-      <p class="text-gray-600">Sign in to continue</p>
+    <div class="flex flex-col items-center justify-center min-h-[60vh] gap-5">
+      <h1 class="text-2xl font-semibold text-gray-900">Semleaf</h1>
+      <p class="text-sm text-gray-500">Sign in to continue</p>
       <a
         href="/api/auth/google"
-        class="px-6 py-3 bg-white border border-gray-300 rounded-lg shadow-sm hover:shadow-md transition-shadow flex items-center gap-3 no-underline text-gray-700"
+        class="px-5 py-2.5 bg-white border border-gray-300 rounded hover:bg-gray-50 transition-colors flex items-center gap-3 no-underline text-sm text-gray-700"
       >
         <svg class="w-5 h-5" viewBox="0 0 24 24">
           <path

--- a/frontend/src/pages/PhraseDetail.tsx
+++ b/frontend/src/pages/PhraseDetail.tsx
@@ -16,7 +16,9 @@ export default function PhraseDetail({ id }: Props) {
     if (!id) return;
     getPhrase(id)
       .then(setPhrase)
-      .catch((e) => setError(e instanceof Error ? e.message : "Failed to load"));
+      .catch((e) =>
+        setError(e instanceof Error ? e.message : "Failed to load"),
+      );
   }, [id]);
 
   const handleDelete = async () => {
@@ -29,25 +31,27 @@ export default function PhraseDetail({ id }: Props) {
     }
   };
 
-  if (error) return <p class="text-red-500">{error}</p>;
+  if (error) return <p class="text-sm text-red-600">{error}</p>;
   if (!phrase) return <p class="text-gray-500">Loading...</p>;
 
   return (
     <div class="max-w-2xl">
-      <div class="bg-white rounded-lg border border-gray-200 p-6">
-        <h2 class="text-xl font-bold text-gray-900 mb-4">{phrase.phrase}</h2>
+      <h1 class="text-xl font-semibold text-gray-900 mb-4">
+        {phrase.phrase}
+      </h1>
 
+      <div class="border border-gray-200 rounded p-5">
         <div class="space-y-4">
           <div>
-            <label class="text-sm font-medium text-gray-500">
+            <label class="text-xs font-medium text-gray-500 uppercase tracking-wider">
               {phrase.meanings.length === 1 ? "Meaning" : "Meanings"}
             </label>
             {phrase.meanings.length === 1 ? (
-              <p class="text-gray-900 mt-1">{phrase.meanings[0]}</p>
+              <p class="text-sm text-gray-900 mt-1">{phrase.meanings[0]}</p>
             ) : (
               <ul class="list-disc list-inside mt-1 space-y-1">
                 {phrase.meanings.map((meaning, i) => (
-                  <li key={i} class="text-gray-900">
+                  <li key={i} class="text-sm text-gray-900">
                     {meaning}
                   </li>
                 ))}
@@ -57,19 +61,23 @@ export default function PhraseDetail({ id }: Props) {
 
           {phrase.source && (
             <div>
-              <label class="text-sm font-medium text-gray-500">Source</label>
-              <p class="text-gray-900 mt-1">{phrase.source}</p>
+              <label class="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Source
+              </label>
+              <p class="text-sm text-gray-900 mt-1">{phrase.source}</p>
             </div>
           )}
 
           {phrase.tags.length > 0 && (
             <div>
-              <label class="text-sm font-medium text-gray-500">Tags</label>
+              <label class="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Tags
+              </label>
               <div class="flex gap-1 mt-1 flex-wrap">
                 {phrase.tags.map((tag) => (
                   <span
                     key={tag}
-                    class="px-2 py-0.5 bg-blue-100 text-blue-800 text-sm rounded-full"
+                    class="px-2 py-0.5 bg-gray-100 text-gray-700 text-xs rounded"
                   >
                     {tag}
                   </span>
@@ -80,33 +88,37 @@ export default function PhraseDetail({ id }: Props) {
 
           {phrase.memo && (
             <div>
-              <label class="text-sm font-medium text-gray-500">Memo</label>
-              <p class="text-gray-900 mt-1 whitespace-pre-wrap">{phrase.memo}</p>
+              <label class="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Memo
+              </label>
+              <p class="text-sm text-gray-900 mt-1 whitespace-pre-wrap">
+                {phrase.memo}
+              </p>
             </div>
           )}
 
           <div class="text-xs text-gray-400">
-            Created: {new Date(phrase.created_at).toLocaleString()} |
-            Updated: {new Date(phrase.updated_at).toLocaleString()}
+            Created: {new Date(phrase.created_at).toLocaleString()} | Updated:{" "}
+            {new Date(phrase.updated_at).toLocaleString()}
           </div>
         </div>
 
-        <div class="flex gap-3 mt-6 pt-4 border-t border-gray-200">
+        <div class="flex gap-2 mt-5 pt-4 border-t border-gray-200">
           <a
             href={`/phrases/${phrase.id}/edit`}
-            class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors no-underline text-sm"
+            class="px-3 py-1.5 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 transition-colors no-underline"
           >
             Edit
           </a>
           <button
             onClick={handleDelete}
-            class="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors text-sm"
+            class="px-3 py-1.5 text-sm border border-red-300 text-red-600 rounded hover:bg-red-50 transition-colors"
           >
             Delete
           </button>
           <a
             href="/"
-            class="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors no-underline text-sm"
+            class="px-3 py-1.5 text-sm border border-gray-300 text-gray-700 rounded hover:bg-gray-50 transition-colors no-underline"
           >
             Back
           </a>

--- a/frontend/src/pages/PhraseForm.tsx
+++ b/frontend/src/pages/PhraseForm.tsx
@@ -67,9 +67,9 @@ export default function PhraseForm({ id }: Props) {
 
   return (
     <div class="max-w-2xl">
-      <h2 class="text-xl font-bold text-gray-900 mb-4">Edit Phrase</h2>
+      <h2 class="text-xl font-semibold text-gray-900 mb-4">Edit Phrase</h2>
 
-      {error && <p class="text-red-500 mb-4">{error}</p>}
+      {error && <p class="text-sm text-red-600 mb-4">{error}</p>}
 
       <form onSubmit={handleSubmit} class="space-y-4">
         <div>
@@ -80,7 +80,7 @@ export default function PhraseForm({ id }: Props) {
             type="text"
             value={phrase}
             onInput={(e) => setPhrase((e.target as HTMLInputElement).value)}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            class="w-full px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
             required
           />
         </div>
@@ -96,17 +96,20 @@ export default function PhraseForm({ id }: Props) {
                   type="text"
                   value={meaning}
                   onInput={(e) =>
-                    updateMeaning(index, (e.target as HTMLInputElement).value)
+                    updateMeaning(
+                      index,
+                      (e.target as HTMLInputElement).value,
+                    )
                   }
                   placeholder={`Meaning ${index + 1}`}
-                  class="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  class="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
                   required
                 />
                 {meanings.length > 1 && (
                   <button
                     type="button"
                     onClick={() => removeMeaning(index)}
-                    class="px-3 py-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors text-sm"
+                    class="px-3 py-1.5 text-red-600 hover:bg-red-50 rounded transition-colors text-sm"
                   >
                     Remove
                   </button>
@@ -117,7 +120,7 @@ export default function PhraseForm({ id }: Props) {
           <button
             type="button"
             onClick={addMeaning}
-            class="mt-2 px-3 py-1 text-blue-600 hover:bg-blue-50 rounded-lg transition-colors text-sm"
+            class="mt-2 px-3 py-1 text-blue-600 hover:bg-blue-50 rounded transition-colors text-sm"
           >
             + Add meaning
           </button>
@@ -131,7 +134,7 @@ export default function PhraseForm({ id }: Props) {
             type="text"
             value={source}
             onInput={(e) => setSource((e.target as HTMLInputElement).value)}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            class="w-full px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
           />
         </div>
 
@@ -150,21 +153,21 @@ export default function PhraseForm({ id }: Props) {
             value={memo}
             onInput={(e) => setMemo((e.target as HTMLTextAreaElement).value)}
             rows={2}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            class="w-full px-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
           />
         </div>
 
-        <div class="flex gap-3 pt-2">
+        <div class="flex gap-2 pt-2">
           <button
             type="submit"
             disabled={loading}
-            class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 text-sm"
+            class="px-4 py-1.5 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 transition-colors disabled:opacity-50"
           >
             {loading ? "Saving..." : "Update"}
           </button>
           <a
             href={`/phrases/${id}`}
-            class="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors no-underline text-sm"
+            class="px-4 py-1.5 text-sm border border-gray-300 text-gray-700 rounded hover:bg-gray-50 transition-colors no-underline"
           >
             Cancel
           </a>

--- a/frontend/src/pages/SearchResults.tsx
+++ b/frontend/src/pages/SearchResults.tsx
@@ -47,22 +47,26 @@ export default function SearchResults({ q, mode }: Props) {
 
   return (
     <div>
+      <h1 class="text-xl font-semibold text-gray-900 mb-4">Search Results</h1>
+
       <div class="mb-6">
         <SearchBox onSearch={handleSearch} initialMode={searchMode} />
       </div>
 
-      {loading && <p class="text-gray-500">Searching...</p>}
-      {error && <p class="text-red-500">{error}</p>}
+      {loading && <p class="text-sm text-gray-500">Searching...</p>}
+      {error && <p class="text-sm text-red-600">{error}</p>}
 
       {!loading && !error && results.length === 0 && q && (
-        <p class="text-gray-500">No results found.</p>
+        <p class="text-sm text-gray-500">No results found.</p>
       )}
 
-      <div class="flex flex-col gap-3">
-        {results.map((phrase) => (
-          <PhraseCard key={phrase.id} phrase={phrase} />
-        ))}
-      </div>
+      {results.length > 0 && (
+        <div class="border border-gray-200 rounded divide-y divide-gray-200">
+          {results.map((phrase) => (
+            <PhraseCard key={phrase.id} phrase={phrase} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace centered hero-style layout with fixed header + left sidebar + main content shell (inspired by Gerrit/Zulip)
- Convert search mode radio buttons to an inline segmented control
- Flatten phrase cards into compact list rows with border separators instead of card shadows
- Standardise flat styling (4px radius, borders over shadows, consistent spacing/typography) across all pages and components
- Add responsive sidebar that collapses to a hamburger drawer on mobile

## Test plan
- [x] All 65 existing tests pass (`vitest run`)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Vite production build succeeds
- [ ] Manual verification: open dev server, check header/sidebar/main layout
- [ ] Manual verification: test search, phrase creation modal, detail/edit pages
- [ ] Manual verification: resize to mobile width, verify sidebar drawer behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)